### PR TITLE
Update RateLimitExceededException.php

### DIFF
--- a/src/Symfony/Component/RateLimiter/Exception/RateLimitExceededException.php
+++ b/src/Symfony/Component/RateLimiter/Exception/RateLimitExceededException.php
@@ -12,6 +12,7 @@
 namespace Symfony\Component\RateLimiter\Exception;
 
 use Symfony\Component\RateLimiter\RateLimit;
+use Symfony\Component\HttpFoundation\Response;
 
 /**
  * @author Kevin Bond <kevinbond@gmail.com>
@@ -22,7 +23,7 @@ class RateLimitExceededException extends \RuntimeException
 {
     private $rateLimit;
 
-    public function __construct(RateLimit $rateLimit, $code = 0, \Throwable $previous = null)
+    public function __construct(RateLimit $rateLimit, $code = Response::HTTP_TOO_MANY_REQUESTS, \Throwable $previous = null)
     {
         parent::__construct('Rate Limit Exceeded', $code, $previous);
 


### PR DESCRIPTION
Change default for `$code` from 0 to `Response::HTTP_TOO_MANY_REQUESTS`.

| Q             | A
| ------------- | ---
| Branch?       | 5.2
| Bug fix?      | yes
| New feature?  | no
| Deprecations? | no
| Tickets       | Fix #40173
| License       | MIT
| Doc PR        | na